### PR TITLE
frontend: add loading message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          repository: TerrorJack/pandoc
+          repository: haskell-wasm/pandoc
           ref: wasm
           path: pandoc
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ non-official) backports for ghc wasm backend's Template Haskell & ghci
 support.
 
 It's built using my
-[fork](https://github.com/TerrorJack/pandoc/tree/wasm) which is based
-on latest `pandoc` release and patches dependencies, cabal config as
-well as some module code to make things compilable to wasm:
+[fork](https://github.com/haskell-wasm/pandoc/tree/wasm) which is
+based on latest `pandoc` release and patches dependencies, cabal
+config as well as some module code to make things compilable to wasm:
 
 - No http client/server functionality. `wasip1` doesn't have proper
   sockets support anyway, and support for future versions of wasi is

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,7 +56,11 @@
   </head>
   <body>
     <div id="container">
-      <textarea id="input" placeholder="Enter your input here..."></textarea>
+      <textarea
+        id="input"
+        readonly
+        placeholder="Loading wasm module..."
+      ></textarea>
       <textarea
         id="output"
         readonly
@@ -68,6 +72,9 @@
     </div>
     <script type="module">
       import { pandoc } from "./index.js";
+
+      document.getElementById("input").readOnly = false;
+      document.getElementById("input").placeholder = "Enter your input here...";
 
       async function updateOutput() {
         const inputText = document.getElementById("input").value;


### PR DESCRIPTION
Add loading message in case of slow client network, `pandoc.wasm` could take a while to download.